### PR TITLE
Bump: faraday

### DIFF
--- a/webfinger.gemspec
+++ b/webfinger.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
-  gem.add_runtime_dependency 'faraday', '~> 2.0'
+  gem.add_runtime_dependency 'faraday', '>= 2.0', '< 3'
   gem.add_runtime_dependency 'faraday-follow_redirects'
   gem.add_runtime_dependency 'activesupport'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
The newest Faraday version is [2.8.10](https://github.com/lostisland/faraday/tree/v2.8.1), but this gem locks 2.0.x.
I've tested this gem with the newest Faraday and saw it all green.
